### PR TITLE
error: use http-custom-errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const httpError = require('http-custom-errors')
 const parseJson = require('safe-json-parse')
 const isReq = require('is-incoming-message')
 const isRes = require('is-server-response')
@@ -38,5 +39,5 @@ function nodeMiddlewareJsonParse (ctx, propName, fmtErr) {
 // default JSON format fn
 // null -> obj
 function dftFmt () {
-  return { message: 'Invalid JSON' }
+  return new httpError.BadRequestError('Invalid JSON')
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "concat-stream": "^1.5.1",
+    "http-custom-errors": "^8.0.0",
     "is-incoming-message": "^1.0.0",
     "is-server-response": "^1.0.0",
     "noop2": "^2.0.0",

--- a/test.js
+++ b/test.js
@@ -56,7 +56,10 @@ test('should return an err on malformed json', function (t) {
     const ctx = {}
     const parse = parseJson(ctx, 'body')
     parse(req, res, function (err) {
-      t.deepEqual(err, { message: 'Invalid JSON' })
+      t.deepEqual(err, {
+        code: 400,
+        status: 'Bad Request'
+      })
       t.deepEqual(ctx, {})
     })
     res.end()


### PR DESCRIPTION
## Changes
- **error**: provide formatted errors using `http-custom-errors` so boilerplate can be reduced
